### PR TITLE
Refactor for -O3 support with POSIX compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,32 +10,29 @@
 #                                                                              #
 # **************************************************************************** #
 
-# FT Library
-TARGET			=	libft.a
-PROJECT_NAME	=	Libft
+# -- Info --
+TARGET			:=	libft.a
+PROJECT_NAME	:=	Libft
 
 MAKEFLAGS		+=	--no-print-directory
-
 .DEFAULT_GOAL	:=	all
 
+# -- Compile Rule --
+CC				:=	cc
+CPPFLAGS		=	$(addprefix -I,$(INC_DIRS)) $(addprefix -D,$(CPPDEFS))
+CFLAGS			=	-Wall -Wextra -Werror
+DEPFLAGS		:=	-MMD -MP
 
-# -compile rule-
-CC				=	gcc
-WARNING_FLAGS	=	-Wall -Wextra -Werror -Wuninitialized
-INC_PATHS		=	$(addprefix -I,$(INC_DIR))
-OPT_FLAGS		=	-O0
-DEPEND_FLAGS	=	-MMD -MP
+AR				:=	ar
+ARFLAGS			:=	rcs
 
-AR				=	ar
-ARFLAGS			=	rcs
+# -- Dir --
+INC_DIRS		=	.
+SRC_DIR			:=	srcs
+OBJ_DIR			:=	objs
 
-# -target dir-
-INC_DIR			=	./
-SRC_DIR			=	srcs/
-OBJ_DIR			=	objs/
-
-# -sources-
-SRCS			=	ft_isalnum.c ft_isalpha.c ft_isascii.c ft_isdigit.c ft_isprint.c \
+# -- Srcs --
+SRCS			:=	ft_isalnum.c ft_isalpha.c ft_isascii.c ft_isdigit.c ft_isprint.c \
 					ft_islower.c ft_isupper.c \
 					ft_memchr.c ft_memcmp.c \
 					ft_strlen.c ft_strchr.c ft_strrchr.c ft_strnstr.c ft_strcmp.c ft_strncmp.c \
@@ -48,9 +45,9 @@ SRCS			=	ft_isalnum.c ft_isalpha.c ft_isascii.c ft_isdigit.c ft_isprint.c \
 					ft_calloc.c \
 					ft_atoi.c ft_itoa.c lite_atof.c \
 					ft_putbit.c ft_isspace.c ft_isvalue.c ft_split_toi.c
-BONUS_SRCS		=	ft_lstnew.c ft_lstadd_front.c ft_lstsize.c ft_lstlast.c ft_lstadd_back.c \
+BONUS_SRCS		:=	ft_lstnew.c ft_lstadd_front.c ft_lstsize.c ft_lstlast.c ft_lstadd_back.c \
 					ft_lstdelone.c ft_lstclear.c ft_lstiter.c ft_lstmap.c
-EXTRA_SRCS		=	get_next_line.c perrturn.c ret_errmsg.c # ft_strtol.c
+EXTRA_SRCS		:=	get_next_line.c perrturn.c ret_errmsg.c # ft_strtol.c
 
 TARGET_SRCS		=	$(SRCS)
 ifneq ($(filter bonus, $(COMPILE_TYPE)),)
@@ -60,43 +57,50 @@ ifneq ($(filter extra, $(COMPILE_TYPE)),)
 TARGET_SRCS		+=	$(EXTRA_SRCS)
 endif
 
-# -objects-
-OBJS			=	$(patsubst %.c, $(OBJ_DIR)%.o, $(TARGET_SRCS))
-DEPS			=	$(patsubst %.c, $(OBJ_DIR)%.d, $(TARGET_SRCS))
+# -- Objs --
+OBJS			:=	$(patsubst %.c, $(OBJ_DIR)/%.o, $(TARGET_SRCS))
+DEPS			:=	$(OBJS:.o=.d)
 
-# -include-
--include $(DEPS)
+# -- Arg Rule --
+CPPDEFS			+=	$(DEF)
 
--include libarith/libarith.mk
+ifeq ($(DEBUG),1)
+CFLAGS			+=	-g -Og  -Wuninitialized -Wfatal-errors -Wshadow
+else
+CFLAGS			+=	-O0
+endif
 
-# -color code-
-RED				=	"\033[1;31m"
-GREEN			= 	"\033[1;32m"
-YELLOW			=	"\033[1;33m"
-CYAN			=	"\033[1;36m"
-WHITE			=	"\033[1;37m"
-RESET			=	"\033[0m"
+# --color code--
+RED				:=	"\033[1;31m"
+GREEN			:= 	"\033[1;32m"
+YELLOW			:=	"\033[1;33m"
+CYAN			:=	"\033[1;36m"
+WHITE			:=	"\033[1;37m"
+RESET			:=	"\033[0m"
 
-
-# --rule--
+# -- Rules --
+.PHONY: all
 all: $(TARGET)
 
-$(TARGET): $(OBJS)	
-	$(AR) $(ARFLAGS) $@ $^
+$(TARGET): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $<
 	@echo $(GREEN)"--- $(PROJECT_NAME) compiled successfully $(COMPILE_TYPE) ---"$(RESET)
 
-$(OBJ_DIR)%.o: $(SRC_DIR)%.c | $(OBJ_DIR)
-	$(CC) $(WARNING_FLAGS) $(OPT_FLAGS) $(INC_PATHS) $(DEPEND_FLAGS) -c $< -o $@
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
 $(OBJ_DIR):
 	@mkdir -p $(OBJ_DIR)
 
+.PHONY: bonus
 bonus:
 	@$(MAKE) all COMPILE_TYPE=bonus
 
+.PHONY: extra
 extra:
 	@$(MAKE) all COMPILE_TYPE=extra
 
+.PHONY: clean
 clean:
 	@if [ -d $(OBJ_DIR) ]; then \
 		rm -rf $(OBJ_DIR); \
@@ -105,11 +109,13 @@ clean:
 		echo $(CYAN)"$(PROJECT_NAME) object has already been deleted."$(RESET); \
 	fi
 
+.PHONY: fclean
 ifeq ($(SKIP_CLEAN), 1)
-fclean: $(CLEAN_TARGETS)
+fclean:
 else
-fclean: clean $(CLEAN_TARGETS)
+fclean: clean
 endif
+	$(MAKE) $(CLEAN_TARGETS)
 	@if [ -f $(TARGET) ]; then \
 		rm -f $(TARGET); \
 		echo $(RED)"$(PROJECT_NAME) $(TARGET) has been deleted !"$(RESET); \
@@ -117,6 +123,10 @@ endif
 		echo $(CYAN)"$(PROJECT_NAME) archive has already been deleted."$(RESET); \
 	fi
 
-re: fclean all
+.PHONY: re
+re: fclean
+	$(MAKE) all
 
-.PHONY: all bonus extra clean fclean re
+# -- Include --
+-include $(CPPDEPS)
+-include libarith/libarith.mk

--- a/get_next_line.h
+++ b/get_next_line.h
@@ -13,7 +13,7 @@
 #ifndef GET_NEXT_LINE_H
 # define GET_NEXT_LINE_H
 
-#include <sys/types.h>
+# include <sys/types.h>
 
 /* get_next_line.c */
 char	*get_next_line(int fd);

--- a/internal/get_next_line.h
+++ b/internal/get_next_line.h
@@ -12,12 +12,9 @@
 
 #ifndef INTERNAL_GET_NEXT_LINE_H
 # define INTERNAL_GET_NEXT_LINE_H
-
-# include <bits/posix1_lim.h>
 # include <limits.h>
 # include <unistd.h>
 # include <stddef.h>
-# include <sys/user.h>
 
 # ifndef STASH_LIMIT
 #  define STASH_LIMIT 128
@@ -25,14 +22,6 @@
 
 # ifndef MAX_LINE_LENGTH
 #  define MAX_LINE_LENGTH SSIZE_MAX
-# endif
-
-# ifndef GNL_BUFFER_MAX
-#  ifdef __linux__
-#   define GNL_BUFFER_MAX (INT_MAX & PAGE_MASK)
-#  else
-#   define GNL_BUFFER_MAX SSIZE_MAX
-#  endif
 # endif
 
 # ifndef BUFFER_SIZE
@@ -47,7 +36,7 @@ enum e_gnl_buffer_size_check
 {
 	GNL_BUFFER_SIZE_MUST_BE_POSITIVE = 1 / (!!(0 < BUFFER_SIZE)),
 	GNL_BUFFER_SIZE_MUST_FIT_READ = 1 / (!!((size_t)BUFFER_SIZE
-			<= (size_t)GNL_BUFFER_MAX))
+			<= (size_t)MAX_LINE_LENGTH))
 };
 
 typedef struct s_byte_array

--- a/libarith/libarith.mk
+++ b/libarith/libarith.mk
@@ -58,7 +58,6 @@ $(ARITH_TARGET): $(ARITH_OBJS)
 
 $(ARITH_OBJ_DIR)/%.o: $(ARITH_SRC_DIR)/%.c | $(ARITH_OBJ_DIR)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
-	@echo $@
 
 $(ARITH_OBJ_DIR):
 	@mkdir -p $(ARITH_OBJ_DIR)

--- a/libarith/libarith.mk
+++ b/libarith/libarith.mk
@@ -46,7 +46,7 @@ ARITH_SRCS			=	q_rsqrt.c \
 
 # -- Objs --
 ARITH_OBJS			=	$(patsubst %.c, $(ARITH_OBJ_DIR)/%.o, $(ARITH_SRCS))
-ARITH_DEPS			=	$(OBJS:.o=.d)
+ARITH_DEPS			=	$(ARITH_OBJS:.o=.d)
 
 # -- Rules --
 .PHONY: arith
@@ -56,8 +56,9 @@ $(ARITH_TARGET): $(ARITH_OBJS)
 	$(AR) $(ARFLAGS) $@ $^
 	@echo $(GREEN)"--- $(ARITH_PROJECT_NAME) compiled successfully ---"$(RESET)
 
-$(ARITH_OBJ_DIR)%.o: $(ARITH_SRC_DIR)%.c | $(ARITH_OBJ_DIR)
+$(ARITH_OBJ_DIR)/%.o: $(ARITH_SRC_DIR)/%.c | $(ARITH_OBJ_DIR)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
+	@echo $@
 
 $(ARITH_OBJ_DIR):
 	@mkdir -p $(ARITH_OBJ_DIR)

--- a/libarith/libarith.mk
+++ b/libarith/libarith.mk
@@ -10,20 +10,21 @@
 #                                                                              #
 # **************************************************************************** #
 
-# Arithmetic Library Module
-ARITH_TARGET		=	libarith.a
+# -- Info --
+ARITH_TARGET		:=	libarith.a
 ARITH_PROJECT_NAME	=	Libarith
 
 CLEAN_TARGETS		+=	arith_clean
 
+# -- Dir --
+INC_DIRS			+=	$(ARITH_INC_DIR)
 
-# -target dir-
-ARITH_DIR			=	libarith/
-ARITH_INC_DIR		=	$(ARITH_DIR)internal/
-ARITH_SRC_DIR		=	$(ARITH_DIR)$(SRC_DIR)
-ARITH_OBJ_DIR		=	$(OBJ_DIR)$(ARITH_DIR)
+ARITH_DIR			=	libarith
+ARITH_INC_DIR		=	$(ARITH_DIR)/internal
+ARITH_SRC_DIR		=	$(ARITH_DIR)/$(SRC_DIR)
+ARITH_OBJ_DIR		=	$(OBJ_DIR)/$(ARITH_DIR)
 
-# -sources-
+# -- Srcs --
 ARITH_SRCS			=	q_rsqrt.c \
 						coord_add.c \
 						coord_sub.c \
@@ -43,18 +44,12 @@ ARITH_SRCS			=	q_rsqrt.c \
 						vec3_sub.c \
 						vec3_to_coord.c \
 
-# -objects-
-ARITH_OBJS			=	$(patsubst %.c, $(ARITH_OBJ_DIR)%.o, $(ARITH_SRCS))
-ARITH_DEPS			=	$(patsubst %.c, $(ARITH_OBJ_DIR)%.d, $(ARITH_SRCS))
+# -- Objs --
+ARITH_OBJS			=	$(patsubst %.c, $(ARITH_OBJ_DIR)/%.o, $(ARITH_SRCS))
+ARITH_DEPS			=	$(OBJS:.o=.d)
 
-# -add to main targets-
-INC_DIR				+=	$(ARITH_INC_DIR)
-
-# -include-
--include $(ARITH_DEPS)
-
-
-# -rule-
+# -- Rules --
+.PHONY: arith
 arith: $(ARITH_TARGET)
 
 $(ARITH_TARGET): $(ARITH_OBJS)
@@ -62,11 +57,12 @@ $(ARITH_TARGET): $(ARITH_OBJS)
 	@echo $(GREEN)"--- $(ARITH_PROJECT_NAME) compiled successfully ---"$(RESET)
 
 $(ARITH_OBJ_DIR)%.o: $(ARITH_SRC_DIR)%.c | $(ARITH_OBJ_DIR)
-	$(CC) $(WARNING_FLAG) $(OPT_FLAGS) $(INC_PATHS) $(DEPEND_FLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
 $(ARITH_OBJ_DIR):
 	@mkdir -p $(ARITH_OBJ_DIR)
 
+.PHONY: arith_clean
 arith_clean:
 	@if [ -f $(ARITH_TARGET) ]; then \
 		rm -f $(ARITH_TARGET); \
@@ -75,4 +71,5 @@ arith_clean:
 		echo $(CYAN)"$(ARITH_PROJECT_NAME) archive has already been deleted."$(RESET); \
 	fi
 
-.PHONY: arith arith_clean
+# -- Include --
+-include $(ARITH_DEPS)

--- a/makefile
+++ b/makefile
@@ -67,7 +67,7 @@ CPPDEFS			+=	$(DEF)
 ifeq ($(DEBUG),1)
 CFLAGS			+=	-g -Og  -Wuninitialized -Wfatal-errors -Wshadow
 else
-CFLAGS			+=	-O0
+CFLAGS			+=	-O3
 endif
 
 # --color code--

--- a/makefile
+++ b/makefile
@@ -128,5 +128,5 @@ re: fclean
 	$(MAKE) all
 
 # -- Include --
--include $(CPPDEPS)
+-include $(DEPS)
 -include libarith/libarith.mk

--- a/makefile
+++ b/makefile
@@ -83,7 +83,7 @@ RESET			:=	"\033[0m"
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $<
+	$(AR) $(ARFLAGS) $@ $^
 	@echo $(GREEN)"--- $(PROJECT_NAME) compiled successfully $(COMPILE_TYPE) ---"$(RESET)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)

--- a/srcs/ft_memmove.c
+++ b/srcs/ft_memmove.c
@@ -27,11 +27,13 @@ void	*ft_memmove(void *dest, const void *src, size_t n)
 		while (n-- > 0)
 			ch_dest[n] = ch_src[n];
 	else
+	{
 		while (i < n)
 		{
 			ch_dest[i] = ch_src[i];
 			i++;
 		}
+	}
 	return (dest);
 }
 

--- a/srcs/ft_putchar_fd.c
+++ b/srcs/ft_putchar_fd.c
@@ -10,11 +10,23 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <errno.h>
 #include <unistd.h>
 
 void	ft_putchar_fd(char c, int fd)
 {
-	write(fd, &c, 1);
+	size_t	len;
+	ssize_t	res;
+
+	len = 1;
+	while (0 < len)
+	{
+		errno = 0;
+		res = write(fd, &c, 1);
+		if (errno == EINTR && -1 == res)
+			continue ;
+		return ;
+	}
 }
 
 // int	main(void)

--- a/srcs/ft_putchar_fd.c
+++ b/srcs/ft_putchar_fd.c
@@ -25,7 +25,9 @@ void	ft_putchar_fd(char c, int fd)
 		res = write(fd, &c, 1);
 		if (errno == EINTR && -1 == res)
 			continue ;
-		return ;
+		else if (res <= 0)
+			return ;
+		len -= (size_t)res;
 	}
 }
 

--- a/srcs/ft_putendl_fd.c
+++ b/srcs/ft_putendl_fd.c
@@ -20,7 +20,7 @@ void	ft_putendl_fd(char *s, int fd)
 	if (s == NULL)
 		return ;
 	ft_putstr_fd(s, fd);
-	write(fd, "\n", 1);
+	ft_putchar_fd('\n', fd);
 }
 
 // int	main(void)

--- a/srcs/ft_putstr_fd.c
+++ b/srcs/ft_putstr_fd.c
@@ -10,14 +10,31 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <errno.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "ft/string.h"
 
 void	ft_putstr_fd(char *str, int fd)
 {
-	if (str)
-		write(fd, str, ft_strlen(str));
+	size_t	len;
+	ssize_t	res;
+
+	if (!str)
+		return ;
+	len = ft_strlen(str);
+	while (0 < len)
+	{
+		errno = 0;
+		res = write(fd, str, len);
+		if (errno == EINTR && -1 == res)
+			continue ;
+		else if (res <= 0)
+			return ;
+		str += res;
+		len -= (size_t)res;
+	}
 }
 
 // void	ft_putstr_fd(char *str, int fd)

--- a/srcs/ft_putstr_fd.c
+++ b/srcs/ft_putstr_fd.c
@@ -12,7 +12,6 @@
 
 #include <errno.h>
 #include <unistd.h>
-#include <limits.h>
 
 #include "ft/string.h"
 

--- a/srcs/get_next_line.c
+++ b/srcs/get_next_line.c
@@ -10,6 +10,8 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include "internal/get_next_line.h"
 
 #include <unistd.h>


### PR DESCRIPTION
This pull request introduces significant improvements to the build system and robustness of output functions, as well as minor cleanups and corrections in header usage and implementation details. The most important changes are grouped below:

**Build System Modernization and Consistency**

* Refactored `Makefile` (now `makefile`) and `libarith/libarith.mk` to use more consistent and modern variable assignment (`:=`), unified directory and object path handling, improved inclusion of dependency files, and added support for debug and optimization flags. Targets and rules are now more clearly separated and use `.PHONY` declarations. [[1]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L13-R35) [[2]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L51-R50) [[3]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L63-R103) [[4]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R112-R132) [[5]](diffhunk://#diff-eeba54b17f512a245becbdedc1b88c61814c46d18a22c2fc7d654c7e1a9413e3L13-R27) [[6]](diffhunk://#diff-eeba54b17f512a245becbdedc1b88c61814c46d18a22c2fc7d654c7e1a9413e3L46-R65) [[7]](diffhunk://#diff-eeba54b17f512a245becbdedc1b88c61814c46d18a22c2fc7d654c7e1a9413e3L78-R75)

**Improved Robustness of Output Functions**

* Updated `ft_putchar_fd` and `ft_putstr_fd` to handle `EINTR` errors from `write()` system calls, making them more robust against interruptions. `ft_putstr_fd` now also handles partial writes correctly. [[1]](diffhunk://#diff-77406a5e7174ddf21237aa2af2ef8edcd4e72232e509d85adcabbb2134f5a7d1R13-R29) [[2]](diffhunk://#diff-da359cc53c22c6a87cc2976abed6b3e01372596e7baa1b09a9ded45fcc442f4cR13-R37)
* Modified `ft_putendl_fd` to use the improved `ft_putchar_fd` for writing the newline character, ensuring consistent error handling.

**Header and Macro Cleanups**

* Cleaned up `internal/get_next_line.h` by removing unnecessary or platform-specific includes and macros, simplifying buffer size handling, and ensuring portability. [[1]](diffhunk://#diff-5b475c53ca5736e78b788eecf2eaad57ffe206dadc4eb6e56aeb69113f8c44c5L15-L20) [[2]](diffhunk://#diff-5b475c53ca5736e78b788eecf2eaad57ffe206dadc4eb6e56aeb69113f8c44c5L30-L37) [[3]](diffhunk://#diff-5b475c53ca5736e78b788eecf2eaad57ffe206dadc4eb6e56aeb69113f8c44c5L50-R39)
* Added `_POSIX_C_SOURCE 200809L` definition in `get_next_line.c` to ensure correct feature set for POSIX compliance.

**Implementation Corrections**

* Fixed a logic error in `ft_memmove` by adding braces to ensure the correct block is executed for the non-overlapping case.